### PR TITLE
change DAI to PUSH token

### DIFF
--- a/docs/notifications/01-build/04-Develop-Create-Channel.mdx
+++ b/docs/notifications/01-build/04-Develop-Create-Channel.mdx
@@ -91,11 +91,11 @@ _`Progress object details`_
 | Progress.id              | Progress.level | Progress.title                                      | Progress.info                                           |
 | ------------------------ | -------------- | --------------------------------------------------- | ------------------------------------------------------- |
 | `PUSH-CHANNEL-CREATE-01` | `INFO`         | Uploading data to IPFS                              | The channel’s data is getting uploaded to IPFS          |
-| `PUSH-CHANNEL-CREATE-02` | `INFO`         | Approving PUSH tokens                               | Gives approval to Push Core contract to spend 50 DAI    |
+| `PUSH-CHANNEL-CREATE-02` | `INFO`         | Approving PUSH tokens                               | Gives approval to Push Core contract to spend 50 $PUSH    |
 | `PUSH-CHANNEL-CREATE-03` | `INFO`         | Channel is getting created                          | Calls Push Core contract to create your channel         |
 | `PUSH-CHANNEL-CREATE-04` | `SUCCESS`      | Channel creation is done, Welcome to Push Ecosystem | Channel creation is completed                           |
 | `PUSH-CHANNEL-UPDATE-01` | `INFO`         | Uploading new data to IPFS                          | The channel’s new data is getting uploaded to IPFS      |
-| `PUSH-CHANNEL-UPDATE-02` | `INFO`         | Approving PUSH tokens                               | Gives approval to Push Core contract to spend 50 DAI    |
+| `PUSH-CHANNEL-UPDATE-02` | `INFO`         | Approving PUSH tokens                               | Gives approval to Push Core contract to spend 50 $PUSH    |
 | `PUSH-CHANNEL-UPDATE-03` | `INFO`         | Channel is getting updated                          | Calls Push Core contract to update your channel details |
 | `PUSH-CHANNEL-UPDATE-04` | `SUCCESS`      | Channel is updated with new data                    | Channel is successfully updated                         |
 | `PUSH-ERROR-02`          | `ERROR`        | Transaction failed for a function call              | Transaction failed                                      |


### PR DESCRIPTION
Refer this issue #426 

Changed DAI token to $PUSH token in docs since the protocol now uses PUSH token
Docs Link: https://push.org/docs/notifications/build/create-channel/